### PR TITLE
Improve performance of `Baseclass.__eq__` and  `Baseclass.__hash__` functions

### DIFF
--- a/python_wrapper/setup.py
+++ b/python_wrapper/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='twa',
-    version='0.0.7',
+    version='0.0.8-15-SNAPSHOT',
     author='Jiaru Bai; Daniel Nurkowski',
     author_email='jb2197@cam.ac.uk; danieln@cmclinnovations.com',
     license='MIT',

--- a/python_wrapper/twa/__init__.py
+++ b/python_wrapper/twa/__init__.py
@@ -1,3 +1,3 @@
 from twa.JPSGateway import JPSGateway
 
-__version__ = "0.0.7"
+__version__ = "0.0.8-15-SNAPSHOT"

--- a/python_wrapper/twa/data_model/base_ontology.py
+++ b/python_wrapper/twa/data_model/base_ontology.py
@@ -1535,9 +1535,12 @@ class BaseClass(BaseModel, validate_assignment=True, validate_default=True):
             # if other doesn't have instance_iri, then it's not comparable
             return False
 
+    __hash_cache__ = None
     def __hash__(self):
         # using instance_iri for hash so that iri and object itself are treated the same in set operations
-        return self.instance_iri.__hash__()
+        if self.__hash_cache__ is None:
+            self.__hash_cache__ = self.instance_iri.__hash__()
+        return self.__hash_cache__
         # TODO [future] do we want to provide the method to compare if the content of two instances are the same?
         # a use case would be to compare if the chemicals in the two bottles are the same concentration
         # return self._make_hash_sha256_(self.dict(exclude=self._exclude_keys_for_compare_()))

--- a/python_wrapper/twa/data_model/base_ontology.py
+++ b/python_wrapper/twa/data_model/base_ontology.py
@@ -1529,7 +1529,11 @@ class BaseClass(BaseModel, validate_assignment=True, validate_default=True):
         return set(tuple(list_keys_to_exclude))
 
     def __eq__(self, other: Any) -> bool:
-        return self.__hash__() == other.__hash__()
+        try:
+            return self.instance_iri == other.instance_iri
+        except TypeError:
+            # if other doesn't have instance_iri, then it's not comparable
+            return False
 
     def __hash__(self):
         # using instance_iri for hash so that iri and object itself are treated the same in set operations


### PR DESCRIPTION
Use caching and string comparing to improve performance