### PR TITLE
fix: updated dependencies in setup.py and docker_test_requirements.txt #26

### DIFF
--- a/python_derivation_agent/docker_test_requirements.txt
+++ b/python_derivation_agent/docker_test_requirements.txt
@@ -1,2 +1,8 @@
-testcontainers
-pytest
+testcontainers>=3.4.2
+pytest==6.2.3
+docker==6.1.3
+pytest-rerunfailures==10.2
+pytest-docker-compose==3.2.1
+requests==2.31.0
+requests-unixsocket==0.3.0
+

--- a/python_derivation_agent/setup.py
+++ b/python_derivation_agent/setup.py
@@ -14,13 +14,5 @@ setup(
     packages=find_namespace_packages(exclude=['tests','tests.*']),
     # Werkzeug version is fixed as its 3.0.0 version breaks flask 2.x https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-0
     install_requires=['py4jps>=1.0.38', 'flask==2.1.0', 'gunicorn==20.0.4', 'Flask-APScheduler', 'rdflib', 'python-dotenv', 'yagmail', 'Werkzeug~=2.2.2'],
-    extras_require={
-        "dev": [
-            "testcontainers>=3.4.2",
-            "pytest>=6.2.3",
-            "pytest-docker-compose>=3.2.1",
-            "pytest-rerunfailures>=10.2"
-        ],
-    },
     include_package_data=True
 )


### PR DESCRIPTION
- moved extras_require dependencies from setup to docker_test_requirements.txt for clarity as the dev options are all for running the tests

- hard specified dependency versions in docjker_test_requirements.txt, as the latest versions will not work

Details regarding to the dependency conflicts can be found in issue #26 