### PR TITLE
removed unused dependencies from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <!-- Please refer to the Versioning page on TheWorldAvatar wiki for
     details on how version numbers should be selected -->
-    <version>1.47.1</version>
+    <version>2.0.0</version>
 
     <!-- Project Properties -->
     <properties>
@@ -145,7 +145,6 @@
     <!-- Dependencies -->
     <!-- If adding dependencies, please include a comment detailing what they're for -->
     <dependencies>
-
         <!-- Servlet API -->
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -164,27 +163,13 @@
             <artifactId>rdf4j-sparqlbuilder</artifactId>
         </dependency>
 
-        <!-- Driver for connecting to postgresql -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-        </dependency>
-
         <!-- ??? -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
 
-        <!-- ??? -->
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-
-        <!-- Spring MVC for Servlet Environments (depends on spring-core, spring-beans, 
-        spring-context, spring-web) Define this if you use Spring MVC with a Servlet 
-        Container such as Apache Tomcat (org.springframework.web.servlet.*) -->
+        <!-- Spring MVC for Servlet Environments -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -199,28 +184,10 @@
             <artifactId>spring-webmvc</artifactId>
         </dependency>
 
-        <!-- ??? -->
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jsch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jsch.agentproxy.jsch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jsch.agentproxy.pageant</artifactId>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
         </dependency>
 
         <!-- Processing JSON content -->
@@ -256,24 +223,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
-            <artifactId>jena-shaded-guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-jdbc-driver-mem</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-jdbc-driver-remote</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-jdbc</artifactId>
-            <type>pom</type>
         </dependency>
 
         <!-- ??? -->
@@ -293,25 +247,8 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
-        <!-- ??? -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
 
-        <!-- ??? -->
-        <dependency>
-            <groupId>net.sf.py4j</groupId>
-            <artifactId>py4j</artifactId>
-        </dependency>
-
-        <!-- Following RDF4J dependencies are added for enabling the federated query
-		feature supported by FedX-->
-        <!-- https://mvnrepository.com/artifact/org.eclipse.rdf4j/rdf4j-repository-http -->
-        <dependency>
-            <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-repository-http</artifactId>
-        </dependency>
+        <!-- Following RDF4J dependencies are added for enabling the federated query feature supported by FedX-->
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-tools-federation</artifactId>
@@ -352,15 +289,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Used to mock environment variables in testing -->
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Used for integration testing to spin up temporary Docker containers with required
-        applications (e.g. postgres, Blazegraph) -->
+        <!-- Used for integration testing to spin up temporary Docker containers with required applications -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
@@ -375,10 +304,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -416,13 +341,6 @@
         <dependency>
             <groupId>net.postgis</groupId>
             <artifactId>postgis-jdbc</artifactId>
-        </dependency>
-
-        <!-- Required to provide classes including
-        'org.glassfish.jersey.internal.RuntimeDelegateImpl' when using JDKs newer that version 8 -->
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updated major version number, to 2.0.0

Removed unused dependencies from pom.xml:

- org.postgresql:postgresql
- commons-lang:commons-lang
- com.jcraft:jsch
- com.jcraft:jsch.agentproxy.pageant
- org.apache.logging.log4j:log4j-core
- org.apache.jena:jena-shaded-guava
- org.apache.jena:jena-jdbc-driver-mem
- org.apache.jena:jena-jdbc (pom)
- commons-codec:commons-codec
- net.sf.py4j:py4j
- org.eclipse.rdf4j:rdf4j-repository-http
- com.github.stefanbirkner:system-lambda
- com.fasterxml.jackson.core:jackson-annotations
- org.glassfish.jersey.core:jersey-common